### PR TITLE
Refactor file writer

### DIFF
--- a/lib/paint_easy/creator.ex
+++ b/lib/paint_easy/creator.ex
@@ -20,7 +20,8 @@ defmodule PaintEasy.Creator do
     pixels = create_pixels(resolution)
 
     image =
-      Map.merge(@pbm_format, resolution)
+      @pbm_format
+      |> Map.merge(resolution)
       |> Map.put(:pixels, pixels)
 
     {:ok, image}

--- a/lib/paint_easy/creator.ex
+++ b/lib/paint_easy/creator.ex
@@ -18,6 +18,7 @@ defmodule PaintEasy.Creator do
   def new_pbm(params \\ []) do
     resolution = get_resolution(params)
     pixels = create_pixels(resolution)
+
     image =
       Map.merge(@pbm_format, resolution)
       |> Map.put(:pixels, pixels)

--- a/lib/paint_easy/parser.ex
+++ b/lib/paint_easy/parser.ex
@@ -1,9 +1,0 @@
-defmodule PaintEasy.Parser do
-  @moduledoc """
-  Documentation for PaintEasy.Parser
-  """
-
-  def pixels_to_string(pixels) do
-    List.flatten(pixels) |> Enum.join(" ")
-  end
-end

--- a/lib/paint_easy/writer.ex
+++ b/lib/paint_easy/writer.ex
@@ -24,5 +24,5 @@ defmodule PaintEasy.Writer do
   defp file_header(%{code: code, width: width, height: height, pixel_limit: pixel_limit}),
     do: "#{code}\n#{width} #{height}\n#{pixel_limit}\n"
 
-  defp file_body(%{pixels: pixels}), do: List.flatten(pixels) |> Enum.join(" ")
+  defp file_body(%{pixels: pixels}), do: pixels |> List.flatten() |> Enum.join(" ")
 end

--- a/lib/paint_easy/writer.ex
+++ b/lib/paint_easy/writer.ex
@@ -1,21 +1,14 @@
 defmodule PaintEasy.Writer do
   alias PaintEasy.Image
-  alias PaintEasy.Parser
 
   @moduledoc """
-  Documentation for PaintEasy.Writer
+  Module to write image file on output device.
   """
 
-  def create_file(path, %Image{
-        height: height,
-        pixel_limit: pixel_limit,
-        pixels: pixels,
-        width: width
-      }) do
-    case File.open("#{path}.pgm", [:write]) do
+  def create_file(image, path) do
+    case File.open("#{path}.pbm", [:write]) do
       {:ok, file} ->
-        IO.binwrite(file, create_header(:pgm, width, height, pixel_limit))
-        IO.binwrite(file, Parser.pixels_to_string(pixels))
+        write_image(image, file)
         :ok
 
       {:error, reason} ->
@@ -23,7 +16,13 @@ defmodule PaintEasy.Writer do
     end
   end
 
-  defp create_header(:pgm, width, height, max_color) do
-    "P2\n#{width} #{height}\n#{max_color}\n"
+  def write_image(%Image{} = image, file) do
+    IO.binwrite(file, file_header(image))
+    IO.binwrite(file, file_body(image))
   end
+
+  defp file_header(%{code: code, width: width, height: height, pixel_limit: pixel_limit}),
+    do: "#{code}\n#{width} #{height}\n#{pixel_limit}\n"
+
+  defp file_body(%{pixels: pixels}), do: List.flatten(pixels) |> Enum.join(" ")
 end

--- a/test/paint_easy/creator_test.exs
+++ b/test/paint_easy/creator_test.exs
@@ -1,4 +1,6 @@
 defmodule PaintEasy.CreatorTest do
+  @moduledoc false
+
   alias PaintEasy.Creator
 
   use ExUnit.Case

--- a/test/paint_easy/creator_test.exs
+++ b/test/paint_easy/creator_test.exs
@@ -5,7 +5,6 @@ defmodule PaintEasy.CreatorTest do
   doctest PaintEasy
 
   describe "new_pbm/2" do
-    @tag pending: true
     test "create new image with width and height" do
       width = 10
       height = 10

--- a/test/paint_easy/writer_test.exs
+++ b/test/paint_easy/writer_test.exs
@@ -1,7 +1,6 @@
 defmodule PaintEasy.WriterTest do
-  @moduledoc """
+  @moduledoc false
 
-  """
   alias PaintEasy.{
     Creator,
     Writer

--- a/test/paint_easy/writer_test.exs
+++ b/test/paint_easy/writer_test.exs
@@ -14,13 +14,11 @@ defmodule PaintEasy.WriterTest do
     test "write pbm image on file" do
       {:ok, image} = Creator.new_pbm(width: 3, height: 3)
 
-      expected = "P1\n3 3\n1\n0 0 0 0 0 0 0 0 0"
-
       file_writed = fn ->
         Writer.write_image(image, :stdio)
       end
 
-      assert capture_io(file_writed) == expected
+      assert capture_io(file_writed) == "P1\n3 3\n1\n0 0 0 0 0 0 0 0 0"
     end
   end
 end

--- a/test/paint_easy/writer_test.exs
+++ b/test/paint_easy/writer_test.exs
@@ -1,0 +1,26 @@
+defmodule PaintEasy.WriterTest do
+  @moduledoc """
+
+  """
+  alias PaintEasy.{
+    Creator,
+    Writer
+  }
+
+  use ExUnit.Case
+  import ExUnit.CaptureIO
+
+  describe "write_image/2" do
+    test "write pbm image on file" do
+      {:ok, image} = Creator.new_pbm(width: 3, height: 3)
+
+      expected = "P1\n3 3\n1\n0 0 0 0 0 0 0 0 0"
+
+      file_writed = fn ->
+        Writer.write_image(image, :stdio)
+      end
+
+      assert capture_io(file_writed) == expected
+    end
+  end
+end


### PR DESCRIPTION
* Remove parser module
* Expose a public function receiving image and io device to be able
to test the file write interception IO device and without use mocks.
* Rewrite header and body writers to use pattern match on image params.